### PR TITLE
Update server Dockerfile to get an updated jenkins version for Java 11

### DIFF
--- a/jenkins/server/Dockerfile
+++ b/jenkins/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.306-jdk8
+FROM jenkins/jenkins:2.340-jdk11
 
 USER root
 


### PR DESCRIPTION
Needed for testing https://github.com/jenkinsci/plasticscm-plugin/pull/71

### Note about jenkins version:
Note that this PR updates Jenkins to version `2.340` (also note that the minimum Jenkins supported by the Jenkins plugin  for build is [2.176.4](https://github.com/jenkinsci/plasticscm-plugin/blob/4ec427b0e3f9918fb59aa4c8c567c392535fb184/pom.xml#L33).

The reason the version needed in the Docker file is bigger is because after installing on version `2.176.4`, Jeknins requires at least 2.332.3 to use the SCM API plugin:
```ava.io.IOException: Failed to load: SCM API Plugin (631.v9143df5b_e4a_a)
 - Jenkins (2.332.3) or higher required
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:962)
	at hudson.PluginManager.dynamicLoad(PluginManager.java:921)
Caused: java.io.IOException: Failed to install scm-api plugin
	at hudson.PluginManager.dynamicLoad(PluginManager.java:934)
	at hudson.model.UpdateCenter$InstallationJob._run(UpdateCenter.java:2183)
Caused: java.io.IOException: Failed to dynamically deploy this plugin
	at hudson.model.UpdateCenter$InstallationJob._run(UpdateCenter.java:2187)
	at hudson.model.UpdateCenter$DownloadJob.run(UpdateCenter.java:1850)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:121)
	at java.lang.Thread.run(Thread.java:748)
```

Additionally, the Credentials plugin also required 2.340 to run, so finally this is the version we use.

```java.io.IOException: Failed to load: Credentials Plugin (credentials 1143.vb_e8b_b_ceee347)
 - Jenkins (2.340) or higher required
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:1018)
	at hudson.PluginManager.dynamicLoad(PluginManager.java:926)
Caused: java.io.IOException: Failed to install credentials plugin
	at hudson.PluginManager.dynamicLoad(PluginManager.java:940)
	at hudson.model.UpdateCenter$InstallationJob._run(UpdateCenter.java:2217)
Caused: java.io.IOException: Failed to dynamically deploy this plugin
	at hudson.model.UpdateCenter$InstallationJob._run(UpdateCenter.java:2221)
	at hudson.model.UpdateCenter$DownloadJob.run(UpdateCenter.java:1867)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:121)
	at java.base/java.lang.Thread.run(Thread.java:829)```
```


